### PR TITLE
obsutil: Fix current extract_dir

### DIFF
--- a/bucket/obsutil.json
+++ b/bucket/obsutil.json
@@ -7,7 +7,7 @@
         "64bit": {
             "url": "https://obs-community.obs.cn-north-1.myhuaweicloud.com/obsutil/current/obsutil_windows_amd64.zip",
             "hash": "4e29f1bf526d429f22e99fd0a1817c2bcc840ded8d49af6c06eca57712056c08",
-            "extract_dir": "obsutil_windows_amd64_4e29f1b"
+            "extract_dir": "obsutil_windows_amd64_5.5.9"
         }
     },
     "bin": "obsutil.exe",


### PR DESCRIPTION
I sugguest huawei to provider a reliable version for autoupdate
This merge just fixed current obsutil installation