### PR TITLE
add pixpin

### DIFF
--- a/bucket/pixpin.json
+++ b/bucket/pixpin.json
@@ -1,10 +1,14 @@
 {
-    "version": "1.0.9.1",
+    "version": "1.1.3.0",
     "description": "功能强大使用简单的截图/贴图工具，帮助你提高效率",
     "homepage": "https://pixpinapp.com/",
     "license": "Freeware",
-    "url": "https://download.pixpinapp.com/PixPin_1.0.9.1.exe",
-    "hash": "7b48058e063808504f3b6c0f08cd13781f6b97db4cf72925122a185e6df72f0d",
+    "architecture": {
+        "64bit": {
+            "url": "https://download.pixpinapp.com/PixPin_1.1.3.0.exe",
+            "hash": "a1552bd9c59fbd03755f9b39a4e88ace7b7c559142bf941d4b9fb2d1c466a9ba"
+        }
+    },
     "innosetup": true,
     "bin": "PixPin.exe",
     "shortcuts": [
@@ -13,18 +17,20 @@
             "PixPin"
         ]
     ],
-    "pre_install": [
-        "if (Test-Path \"$dir\\LocalStorage.data\") { Copy-Item \"$dir\\LocalStorage.data\" \"$persist_dir\" -Force }"
-    ],
+    "post_install": "if (!(Test-Path \"$dir\\Config\\config.json\")) { Set-Content -Encoding ASCII -Path \"$dir\\Config\\config.json\" -Value '{\"System.Update.AutoCheckUpdate\":{\"subConf\":{\"checkBeta\":false},\"value\":false}}' }",
     "persist": [
+        "History",
         "Data",
         "Config"
     ],
     "checkver": {
-        "url": "https://download.pixpinapp.com/",
-        "regex": "PixPin_([\\d+\\.]+)\\.exe"
+        "regex": "PixPin_([\\d.]+).exe"
     },
     "autoupdate": {
-        "url": "https://download.pixpinapp.com/PixPin_$version.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://download.pixpinapp.com/PixPin_$version.exe"
+            }
+        }
     }
 }

--- a/bucket/pixpin.json
+++ b/bucket/pixpin.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.0.9.1",
+    "description": "功能强大使用简单的截图/贴图工具，帮助你提高效率",
+    "homepage": "https://pixpinapp.com/",
+    "license": "Freeware",
+    "url": "https://download.pixpinapp.com/PixPin_1.0.9.1.exe",
+    "hash": "7b48058e063808504f3b6c0f08cd13781f6b97db4cf72925122a185e6df72f0d",
+    "innosetup": true,
+    "bin": "PixPin.exe",
+    "shortcuts": [
+        [
+            "PixPin.exe",
+            "PixPin"
+        ]
+    ],
+    "pre_install": [
+        "if (Test-Path \"$dir\\LocalStorage.data\") { Copy-Item \"$dir\\LocalStorage.data\" \"$persist_dir\" -Force }"
+    ],
+    "persist": [
+        "Data",
+        "Config"
+    ],
+    "checkver": {
+        "url": "https://download.pixpinapp.com/",
+        "regex": "PixPin_([\\d+\\.]+)\\.exe"
+    },
+    "autoupdate": {
+        "url": "https://download.pixpinapp.com/PixPin_$version.exe"
+    }
+}


### PR DESCRIPTION
pixpin 是最近新出的一个很好用的免费截图软件

## 官网

[PixPin 截图/贴图/长截图/文字识别/标注 | PixPin 截图/贴图/长截图/文字识别/标注](https://pixpinapp.com/ )

## 介绍

[几乎完美的截图软件？怕不是冲着Snipaste来的 | PixPin - 贴图、离线OCR、长截图、GIF录制_哔哩哔哩_bilibili](https://www.bilibili.com/video/BV1Vu4y1G7Uw/?spm_id_from=..search-card.all.click&vd_source=676f8b24b99c148b1b81e4550ddd2284 )

## scoop manifest
我不太确定 manifest 有没有写对。

1. 保留文件 `persist` 的设置

从实际运行来看，应该保留 `Data` 和 `Config` 这两个文件夹，还有`LocalStorage.data` 这个文件（软件运行之后产生）。

但是 scoop 会在安装时，给 `LocalStorage.data` 也创建了文件夹的符号链接（junction）
这里的 `pre_install` 试图在安装前，直接拷贝 `LocalStorage.data` 

2. `checkver` 与 `autoupdate` 的设置  

不确定写对没有  🤣

