### PR TITLE
add git-cola

### DIFF
--- a/bucket/git-cola.json
+++ b/bucket/git-cola.json
@@ -1,0 +1,36 @@
+{
+    "version": "4.15.0",
+    "description": "A powerful Git GUI with a slick and intuitive user interface.",
+    "homepage": "https://git-cola.github.io/",
+    "license": "GPL-2.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/git-cola/git-cola/releases/download/v4.15.0/git-cola-4.15.0.windows.zip",
+            "hash": "fa45df6df9ba03c50870cec76442c495c54a72b3caaef4bd147b302579ccf057"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\" 'git-cola-*.exe' | Select-Object -First 1 -ExpandProperty FullName | Expand-7zipArchive -Destination \"$dir\" -Removal",
+    "post_install": "Remove-Item \"$dir\\`$*\" -Force -Recurse -ErrorAction SilentlyContinue",
+    "bin": [
+        "bin\\git-cola.exe",
+        "bin\\git-dag.exe"
+    ],
+    "shortcuts": [
+        [
+            "bin\\git-cola.exe",
+            "git-cola",
+            "",
+            "git-cola.ico"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/git-cola/git-cola"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/git-cola/git-cola/releases/download/v$version/git-cola-$version.windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Git Cola (v4.15.0) to the Windows package catalog.
  - Provides git-cola and git-dag command-line tools after installation.
  - Creates a desktop/start menu shortcut with the Git Cola icon.
  - Supports version checks and streamlined updates via the package manager.

- Chores
  - Improved installation cleanup for a tidier setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->