### PR TITLE
add lazyssh

### DIFF
--- a/bucket/lazyssh.json
+++ b/bucket/lazyssh.json
@@ -1,0 +1,38 @@
+{
+    "version": "0.2.1",
+    "description": "A terminal-based SSH manager inspired by lazydocker and k9s.",
+    "homepage": "https://github.com/Adembc/lazyssh",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Adembc/lazyssh/releases/download/v0.2.1/lazyssh_Windows_x86_64.zip",
+            "hash": "4b266856939d5003292cfbe78a6fc06173fe6e5dfc4a2b89127c0a9d2992243b"
+        },
+        "32bit": {
+            "url": "https://github.com/Adembc/lazyssh/releases/download/v0.2.1/lazyssh_Windows_i386.zip",
+            "hash": "d8f0bbe91ca3ad27e4da2247fd2c7f9201247b917ea2cdbc96c082af643b9e37"
+        },
+        "arm64": {
+            "url": "https://github.com/Adembc/lazyssh/releases/download/v0.2.1/lazyssh_Windows_arm64.zip",
+            "hash": "7a551929365315e7c1cd54a3a1f399840e69bccba52883f52201e64a40689398"
+        }
+    },
+    "bin": "lazyssh.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Adembc/lazyssh/releases/download/v$version/lazyssh_Windows_x86_64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/Adembc/lazyssh/releases/download/v$version/lazyssh_Windows_i386.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Adembc/lazyssh/releases/download/v$version/lazyssh_Windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a Windows package for lazyssh (v0.2.1) available via the package manager.
  * Supports 64-bit, 32-bit, and ARM64 architectures with integrity-verified downloads.
  * Enables automatic update checks and seamless upgrades from GitHub releases.
  * Installs lazyssh.exe for direct command-line use after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->