### PR TITLE
add omnictl

### DIFF
--- a/bucket/omnictl.json
+++ b/bucket/omnictl.json
@@ -2,7 +2,7 @@
     "version": "1.1.5",
     "description": "CLI for the Sidero Omni Kubernetes management platform.",
     "homepage": "https://omni.siderolabs.com/",
-    "license": "BSL-1.1",
+    "license": "BUSL-1.1",
     "architecture": {
         "64bit": {
             "url": "https://github.com/siderolabs/omni/releases/download/v1.1.5/omnictl-windows-amd64.exe#/omnictl.exe",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows package manager support to install and update the Omni Kubernetes CLI (omnictl) via Scoop.
  * Published version 1.1.5 for Windows 64-bit users.
  * Enabled automatic update checks tied to GitHub releases for streamlined upgrades.
  * Included SHA256 checksum verification for secure downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->