### PR TITLE
add kubectl-gadget

### DIFF
--- a/bucket/kubectl-gadget.json
+++ b/bucket/kubectl-gadget.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.44.1",
+    "description": "Collection of gadgets for troubleshooting Kubernetes applications using eBPF.",
+    "homepage": "https://inspektor-gadget.io",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v0.44.1/kubectl-gadget-windows-amd64-v0.44.1.tar.gz",
+            "hash": "80553851834b5e2313dfea4122fb7c95390bfd90fea1839b466c6ef1ec9dbabf"
+        }
+    },
+    "bin": "kubectl-gadget.exe",
+    "checkver": {
+        "github": "https://github.com/inspektor-gadget/inspektor-gadget"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/inspektor-gadget/inspektor-gadget/releases/download/v$version/kubectl-gadget-windows-amd64-v$version.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added kubectl-gadget (v0.44.1) package for Windows 64-bit to the bucket, enabling easy install and direct use of the gadget binary.
  - Includes secure downloads with SHA256 verification, automatic tracking of upstream releases for seamless updates, and version checks to keep installations current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->