### PR TITLE
psst: Use release bins instead of actions artifacts

### DIFF
--- a/bucket/psst.json
+++ b/bucket/psst.json
@@ -5,25 +5,25 @@
     "license": "MIT",
     "architecture": {
         "64bit": {
-            "url": "https://nightly.link/jpochyla/psst/actions/runs/16540690249/Psst.exe.zip",
-            "hash": "53cd9f79ac2c9716d0abcbeabc9e696656557ae392bfbff2179c919ece462645"
+            "url": "https://github.com/jpochyla/psst/releases/download/rolling/Psst.exe",
+            "hash": "e486a0d9bca7286bd25fffc57330940211638cc7660545f98f70aab266455230"
         }
     },
     "shortcuts": [
         [
-            "psst-gui.exe",
+            "Psst.exe",
             "Psst"
         ]
     ],
     "notes": "A Spotify Premium account is required.",
     "checkver": {
-        "url": "https://github.com/jpochyla/psst/actions/workflows/build.yml?query=branch%3Amain+is%3Asuccess+event%3Apush",
-        "regex": "(?sm)/actions/runs/(?<run>\\d+)\".*?#(\\d+):"
+        "url": "https://api.github.com/repositories/267374872/actions/workflows/build.yml/runs?branch=main&status=success",
+        "jsonpath": "$.workflow_runs[0].run_number"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://nightly.link/jpochyla/psst/actions/runs/$matchRun/Psst.exe.zip"
+                "url": "https://github.com/jpochyla/psst/releases/download/rolling/Psst.exe"
             }
         }
     }

--- a/bucket/psst.json
+++ b/bucket/psst.json
@@ -1,5 +1,5 @@
 {
-    "version": "1272",
+    "version": "2025.07.26-31861f4",
     "description": "A fast Spotify client with native GUI.",
     "homepage": "https://github.com/jpochyla/psst",
     "license": "MIT",
@@ -17,8 +17,9 @@
     ],
     "notes": "A Spotify Premium account is required.",
     "checkver": {
-        "url": "https://api.github.com/repositories/267374872/actions/workflows/build.yml/runs?branch=main&status=success",
-        "jsonpath": "$.workflow_runs[0].run_number"
+        "url": "https://api.github.com/repositories/267374872/releases/tags/rolling",
+        "jsonpath": "$.name",
+        "regex": "\\AContinuous release \\(([^)]+)\\)\\Z"
     },
     "autoupdate": {
         "architecture": {


### PR DESCRIPTION
The artifacts get published as release bins under the `rolling` tag. Actions artifacts aren't hosted forever, they have an expiry, releases don't.

Another `checkver` option's to use the date+commit in the release title instead of the workflow run number, it's a bit easier to understand Imo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shortcut now launches the correct executable (Psst.exe), preventing launch issues.

* **Chores**
  * Updated app version to latest release.
  * Moved 64-bit downloads to official release assets for more stable installs.
  * Updated checksum to match the new release artifact.
  * Switched version checking to GitHub API and adjusted auto-update to track official releases for more reliable updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->