### PR TITLE
add git-who

### DIFF
--- a/bucket/git-who.json
+++ b/bucket/git-who.json
@@ -1,0 +1,22 @@
+{
+    "version": "1.2",
+    "description": "Git blame for file trees.",
+    "homepage": "https://github.com/sinclairtarget/git-who",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sinclairtarget/git-who/releases/download/v1.2/gitwho_v1.2_windows_amd64.tar.gz",
+            "extract_dir": "windows_amd64",
+            "hash": "3b79dd5d2e920caee3f16d08b32882da06e879a198ebccc4d190aa46fa1fa53d"
+        }
+    },
+    "bin": "git-who.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sinclairtarget/git-who/releases/download/v$version/gitwho_v$version_windows_amd64.tar.gz"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Windows 64-bit package manifest for git-who, enabling installation via Scoop.
  * Includes version 1.2 with verified checksum, binary mapping (git-who.exe), and metadata (description, homepage, license).
  * Supports GitHub-based version checks and auto-update of the download URL for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->