### PR TITLE
add opus-tools

### DIFF
--- a/bucket/opus-tools.json
+++ b/bucket/opus-tools.json
@@ -1,0 +1,31 @@
+{
+    "version": "2025.12.17",
+    "description": "(Unofficial Builds by Chocobo1) Command-line utilities to encode, inspect, and decode .opus files.",
+    "homepage": "https://gitlab.xiph.org/xiph/opus-tools",
+    "license": "BSD-2-Clause|GPL-2.0-only",
+    "url": "https://github.com/Chocobo1/opus-tools_win32-build/releases/download/2025.12.17/opus-tools.exe#/dl.7z",
+    "hash": "2a8cc64d5cce63f739c6a7d931c86112cc90e4d62795fa45cacdc49aec5d5df4",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "opus-tools\\x64"
+        },
+        "32bit": {
+            "extract_dir": "opus-tools\\win32"
+        }
+    },
+    "bin": [
+        "opusinfo.exe",
+        "opusenc.exe",
+        "opusdec.exe"
+    ],
+    "checkver": {
+        "url": "https://github.com/Chocobo1/opus-tools_win32-build/releases.atom",
+        "regex": "Repository/\\d+/(.+?)<"
+    },
+    "autoupdate": {
+        "url": "https://github.com/Chocobo1/opus-tools_win32-build/releases/download/$version/opus-tools.exe#/dl.7z",
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Opus tools are now installable via Scoop package manager for Windows, supporting both 64-bit and 32-bit architectures with automatic updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->