### PR TITLE
add mariokart64recomp

### DIFF
--- a/bucket/mariokart64recomp.json
+++ b/bucket/mariokart64recomp.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.9.1",
+    "description": "MarioKart 64: Recompiled is a project that uses N64: Recompiled to statically recompile MarioKart 64 into a native port with many new features and enhancements.",
+    "homepage": "https://github.com/sonicdcer/MarioKart64Recomp",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/sonicdcer/MarioKart64Recomp/releases/download/v0.9.1/MarioKart64Recompiled-v0.9.1-Windows-RelWithDebInfo.zip",
+            "hash": "42aaa196713ffa751a10917dd50dd7a61709a5f3c1f9f52a20d919cf19713469"
+        }
+    },
+    "shortcuts": [
+        [
+            "MarioKart64Recompiled.exe",
+            "MarioKart 64 Recompiled"
+        ]
+    ],
+    "pre_install": "if (!(Test-Path \"$dir\\portable.txt\")) { Set-Content -Encoding ASCII -Path \"$dir\\portable.txt\" -Value $null }",
+    "post_install": "Get-ChildItem \"$persist_dir\\*\" -Include '*.json', '*.bak', '*.sav', '*.z64', '*.n64' | Move-Item -Force -Destination $dir",
+    "pre_uninstall": "Get-ChildItem \"$dir\\*\" -Include '*.json', '*.bak', '*.sav', '*.z64', '*.n64' | Move-Item -Force -Destination $persist_dir",
+    "persist": [
+        "saves",
+        "mods",
+        "mod_config"
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/sonicdcer/MarioKart64Recomp/releases/download/v$version/MarioKart64Recompiled-v$version-Windows-RelWithDebInfo.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Scoop package manager support for MarioKart64 Recompiled version 0.9.1, enabling convenient installation, automatic version updates, and persistent storage of saves and mods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->