### PR TITLE
picocrypt-ng@2.05: Fix hash

### DIFF
--- a/bucket/picocrypt-ng.json
+++ b/bucket/picocrypt-ng.json
@@ -6,7 +6,7 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/Picocrypt-NG/Picocrypt-NG/releases/download/2.05/Picocrypt-NG.exe",
-            "hash": "e64ee42f169c3ed54faa4d450c39eec634d89aa84800faf0bfbc5fa83d40642e"
+            "hash": "49a85f16eeabf09c7d7becac104b2a08827bc7aee73e585b50cabb7e25401d4b"
         }
     },
     "shortcuts": [


### PR DESCRIPTION
- Closes #2550