### PR TITLE
add kaitai-struct-compiler

### DIFF
--- a/bucket/kaitai-struct-compiler.json
+++ b/bucket/kaitai-struct-compiler.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.11",
+    "description": "The official reference compiler for Kaitai Struct, a declarative language for describing binary data structures.",
+    "homepage": "https://kaitai.io/",
+    "license": "GPL-3.0-or-later",
+    "url": "https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/0.11/kaitai-struct-compiler-0.11.zip",
+    "hash": "ff89389d9dc9e770d78a24af328763cb1f8e7b31ce7766c9edf10669a060f2a2",
+    "extract_dir": "kaitai-struct-compiler-0.11",
+    "bin": "bin\\kaitai-struct-compiler.bat",
+    "suggest": {
+        "JDK": [
+            "java/openjdk",
+            "java/temurin-jdk",
+            "java/oraclejdk",
+            "java/zulu-jdk"
+        ]
+    },
+    "checkver": {
+        "github": "https://github.com/kaitai-io/kaitai_struct_compiler"
+    },
+    "autoupdate": {
+        "url": "https://github.com/kaitai-io/kaitai_struct_compiler/releases/download/$version/kaitai-struct-compiler-$version.zip",
+        "extract_dir": "kaitai-struct-compiler-$version"
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package manager manifest for Kaitai Struct Compiler version 0.11, enabling installation and automated updates through Scoop with configured dependencies and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->