### PR TITLE
add lap

### DIFF
--- a/bucket/lap.json
+++ b/bucket/lap.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.1.11",
+    "description": "An offline-first photo manager for large local libraries.",
+    "homepage": "https://github.com/julyx10/lap",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/julyx10/lap/releases/download/v0.1.11/Lap_0.1.11_x64_en-US.msi",
+            "hash": "dd818f01f9606f46a4fd520ed4a286390977d15c69c6ad387f85509fc6f8b956"
+        }
+    },
+    "extract_dir": "PFiles\\Lap",
+    "shortcuts": [
+        [
+            "Lap.exe",
+            "Lap"
+        ]
+    ],
+    "post_uninstall": "if ($purge) { Remove-Item \"$env:APPDATA\\com.julyx10.lap\", \"$env:LOCALAPPDATA\\com.julyx10.lap\" -Force -Recurse -ErrorAction SilentlyContinue }",
+    "notes": [
+        "Lap is NOT portable.",
+        "Settings are stored in '%LOCALAPPDATA%\\com.julyx10.lap', and can be purged using 'scoop uninstall --purge lap'."
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/julyx10/lap/releases/download/v$version/Lap_$version_x64_en-US.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lap v0.1.11 package—an offline-first photo manager for Windows 64-bit—with auto-update support configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->