### PR TITLE
add akregator-nightly

### DIFF
--- a/bucket/akregator-nightly.json
+++ b/bucket/akregator-nightly.json
@@ -1,6 +1,6 @@
 {
     "version": "2601",
-    "description": "A RSS feed reader developed by KDE.",
+    "description": "An RSS feed reader developed by KDE.",
     "homepage": "https://apps.kde.org/akregator/",
     "license": "GPL-2.0-or-later",
     "architecture": {
@@ -12,7 +12,7 @@
     "shortcuts": [
         [
             "bin\\akregator.exe",
-            "Akregator"
+            "Akregator Nightly"
         ]
     ],
     "notes": "Akregator is NOT portable.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for KDE Akregator nightly builds on 64-bit Windows.
  * Installer adds an "Akregator Nightly" shortcut and marks the app as non‑portable.
  * Automatic nightly version detection and artifact updates with integrity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->