### PR TITLE
add mxc

### DIFF
--- a/bucket/mxc.json
+++ b/bucket/mxc.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.6.1",
+    "description": "Microsoft eXecution Container (MXC) is a sandboxed code execution system for running untrusted code (model output, plugins, tools) on Windows, Linux, and macOS.",
+    "homepage": "https://github.com/microsoft/mxc",
+    "license": "MIT",
+    "url": "https://github.com/microsoft/mxc/releases/download/v0.6.1/mxc-release-binaries.zip",
+    "hash": "d33606781ad7005cf6e9805cc5bb7b5c129cfa8d02a57826fca3998d9d24364d",
+    "architecture": {
+        "64bit": {
+            "extract_dir": "x64"
+        },
+        "arm64": {
+            "extract_dir": "arm64"
+        }
+    },
+    "bin": [
+        "wxc-exec.exe",
+        "mxc-diagnostic-console.exe"
+    ],
+    "post_install": "Remove-Item \"$dir\\lxc-exec\", \"$dir\\mxc-exec-mac\", \"$dir\\linux-test-proxy\", \"$dir\\symbols\" -Force -Recurse -ErrorAction SilentlyContinue",
+    "checkver": "github",
+    "autoupdate": {
+        "url": "https://github.com/microsoft/mxc/releases/download/v$version/mxc-release-binaries.zip"
+    }
+}

--- a/bucket/mxc.json
+++ b/bucket/mxc.json
@@ -18,7 +18,10 @@
         "mxc-diagnostic-console.exe"
     ],
     "post_install": "Remove-Item \"$dir\\lxc-exec\", \"$dir\\mxc-exec-mac\", \"$dir\\linux-test-proxy\", \"$dir\\symbols\" -Force -Recurse -ErrorAction SilentlyContinue",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/microsoft/mxc/releases.atom",
+        "regex": "Repository/\\d+/v(.+?)<"
+    },
     "autoupdate": {
         "url": "https://github.com/microsoft/mxc/releases/download/v$version/mxc-release-binaries.zip"
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a Scoop package manifest for Microsoft eXecution Container (MXC) v0.6.1 to enable installation and management via Scoop; includes 64-bit and ARM64 support, shipped command-line executables, SHA256 verification, automated post-install cleanup, and GitHub releases–based automatic version checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->