### PR TITLE
add anywherelan

### DIFF
--- a/bucket/anywherelan.json
+++ b/bucket/anywherelan.json
@@ -1,0 +1,44 @@
+{
+    "version": "0.18.0",
+    "description": "Anywherelan (awl for brevity) is a peer-to-peer mesh VPN for connecting your own devices to each other, at the IP level, from wherever they are.",
+    "homepage": "https://anywherelan.com/",
+    "license": "MPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/anywherelan/awl/releases/download/v0.18.0/awl-windows-amd64-v0.18.0.zip",
+            "hash": "0673e7659b11c68de062def4d5baeb038f8fd59b20f0165ea6918926aeb08004"
+        },
+        "32bit": {
+            "url": "https://github.com/anywherelan/awl/releases/download/v0.18.0/awl-windows-386-v0.18.0.zip",
+            "hash": "7598d565579ad5f570615bd20d59e6b928ecff6c6c7b820b991bededdc9a2779"
+        },
+        "arm64": {
+            "url": "https://github.com/anywherelan/awl/releases/download/v0.18.0/awl-windows-arm64-v0.18.0.zip",
+            "hash": "c66920d497a4884542e99b9e66467c5c5cf81fc681cf3cd9c091d5839a63c23a"
+        }
+    },
+    "shortcuts": [
+        [
+            "awl-tray.exe",
+            "Anywherelan"
+        ]
+    ],
+    "pre_install": "if (!(Test-Path \"$persist_dir\\config_awl.json\")) { Set-Content -Encoding ASCII -Path \"$dir\\config_awl.json\" -Value \"{}\" }",
+    "persist": "config_awl.json",
+    "checkver": {
+        "github": "https://github.com/anywherelan/awl"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/anywherelan/awl/releases/download/v$version/awl-windows-amd64-v$version.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/anywherelan/awl/releases/download/v$version/awl-windows-386-v$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/anywherelan/awl/releases/download/v$version/awl-windows-arm64-v$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and updating Anywherelan on Windows, including 64-bit, 32-bit, and ARM64 builds.
  * Enabled automatic version checking and autoupdates.
  * Added setup behavior for creating and preserving the app’s config file during installation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->