### PR TITLE
fix(taskexplorer): remove incorrect extract_dir causing missing exe

### DIFF
--- a/bucket/taskexplorer.json
+++ b/bucket/taskexplorer.json
@@ -6,17 +6,6 @@
     "url": "https://github.com/DavidXanatos/TaskExplorer/releases/download/v1.8.0/TaskExplorer-v1.8.0.exe",
     "hash": "e40af0d5cfd43091e626eda631cbc53d4804db129b602180d05d47be137cf744",
     "innosetup": true,
-    "architecture": {
-        "64bit": {
-            "extract_dir": "x64"
-        },
-        "32bit": {
-            "extract_dir": "x86"
-        },
-        "arm64": {
-            "extract_dir": "ARM64"
-        }
-    },
     "shortcuts": [
         [
             "TaskExplorer.exe",


### PR DESCRIPTION
## Problem

Installing taskexplorer fails to create shortcut because TaskExplorer.exe cannot be found after extraction.

```
Creating shortcut for Task Explorer (TaskExplorer.exe) failed: Couldn't find C:\Users\Fang\scoop\apps\taskexplorer\current\TaskExplorer.exe
```

## Root Cause

The manifest specifies `extract_dir` for each architecture, but the Inno Setup archive structure does NOT place the main exe inside architecture-specific subdirectories:

- `{app}\` (root): TaskExplorer.exe, all DLLs, TaskHelper.exe
- `{app}\x64\`: Only TaskExplorer.ini
- `{app}\x86\`: Only TaskHelper.exe (helper, not main exe)
- `{app}\AMD64\`: Kernel driver files only
- `{app}\ARM64\`: Kernel driver files only

When Scoop extracts with `extract_dir: x64`, it gets a directory containing only an ini file -- no exe.

## Fix

Remove the `architecture` block entirely. The main TaskExplorer.exe is a universal binary at the archive root, shared across all architectures. This fix is correct for 64bit, 32bit, and arm64 users alike.

Verified by inspecting the archive with innounp and by successfully reinstalling after the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the installer manifest by removing per-CPU directory mapping settings.
  * The setup configuration now skips directly to shortcut definitions, reducing unnecessary complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->