### PR TITLE
fix(rebased): update shortcut executable

### DIFF
--- a/bucket/rebased.json
+++ b/bucket/rebased.json
@@ -11,7 +11,7 @@
     },
     "shortcuts": [
         [
-            "bin\\idea64.exe",
+            "bin\\rebased64.exe",
             "Rebased"
         ]
     ],


### PR DESCRIPTION
Update the Rebased shortcut target from `bin\idea64.exe` to `bin\rebased64.exe`, matching the executable included in version 1.1.8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the 64-bit application shortcut to launch the correct executable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->