### PR TITLE
pdf-oxide: Add version 0.3.74

### DIFF
--- a/bucket/pdf-oxide.json
+++ b/bucket/pdf-oxide.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.3.74",
+    "description": "A command-line tool for PDF text extraction, markdown conversion, search, merge, split, image extraction, and more.",
+    "homepage": "https://oxide.fyi/",
+    "license": "Apache-2.0|MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yfedoseev/pdf_oxide/releases/download/v0.3.74/pdf_oxide-windows-x86_64-0.3.74.zip",
+            "hash": "a33023fa7ccd4dd66e35ab3bffdb5d63d2d7c5df6b3a3d35ffe47b1b98a31da7"
+        }
+    },
+    "bin": [
+        "pdf-oxide.exe",
+        "pdf-oxide-mcp.exe"
+    ],
+    "checkver": {
+        "github": "https://github.com/yfedoseev/pdf_oxide"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yfedoseev/pdf_oxide/releases/download/v$version/pdf_oxide-windows-x86_64-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package support for the `pdf-oxide` command-line tool on Windows x86_64.
  * Included both `pdf-oxide` and `pdf-oxide-mcp` executables.
  * Enabled version tracking and automatic updates through GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->