### PR TITLE
pagefind: Add version 1.5.2

### DIFF
--- a/bucket/pagefind-extended.json
+++ b/bucket/pagefind-extended.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.5.2",
+    "description": "A static search engine with extended language support, including CJK tokenization.",
+    "homepage": "https://pagefind.app/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Pagefind/pagefind/releases/download/v1.5.2/pagefind_extended-v1.5.2-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "7ba298054764dfb3c5b982a1eb92607bea8ecaec20a923fc8a4dfd68272ae8a2"
+        },
+        "arm64": {
+            "url": "https://github.com/Pagefind/pagefind/releases/download/v1.5.2/pagefind_extended-v1.5.2-aarch64-pc-windows-msvc.tar.gz",
+            "hash": "4fd44a27ecc7ac517e1293e8d9e31073d1cf16d457f3126c31374c69e836df43"
+        }
+    },
+    "bin": "pagefind_extended.exe",
+    "checkver": {
+        "github": "https://github.com/Pagefind/pagefind"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Pagefind/pagefind/releases/download/v$version/pagefind_extended-v$version-x86_64-pc-windows-msvc.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/Pagefind/pagefind/releases/download/v$version/pagefind_extended-v$version-aarch64-pc-windows-msvc.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/pagefind.json
+++ b/bucket/pagefind.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.5.2",
+    "description": "A fully static search engine that aims to perform well on large sites.",
+    "homepage": "https://pagefind.app/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Pagefind/pagefind/releases/download/v1.5.2/pagefind-v1.5.2-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "fab125d5e8e2d3481ffe7d36dec6e101f54a6581cd51cf5e2e09220d4bc78e9c"
+        },
+        "arm64": {
+            "url": "https://github.com/Pagefind/pagefind/releases/download/v1.5.2/pagefind-v1.5.2-aarch64-pc-windows-msvc.tar.gz",
+            "hash": "c4d869293a9cd5c14c2dff7e7f568b27a5f4acb1124a2097b638cffc0d82b840"
+        }
+    },
+    "bin": "pagefind.exe",
+    "checkver": {
+        "github": "https://github.com/Pagefind/pagefind"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Pagefind/pagefind/releases/download/v$version/pagefind-v$version-x86_64-pc-windows-msvc.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/Pagefind/pagefind/releases/download/v$version/pagefind-v$version-aarch64-pc-windows-msvc.tar.gz"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added package metadata for Pagefind and Pagefind Extended version 1.5.2.
  * Added installation support for 64-bit and ARM64 Windows systems.
  * Added automatic update information and download verification through SHA256 checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->