### PR TITLE
ctrtool: Add version 1.3.0

### DIFF
--- a/bucket/ctrtool.json
+++ b/bucket/ctrtool.json
@@ -2,6 +2,7 @@
     "version": "1.3.0",
     "description": "A general purpose reading/extraction tool for Nintendo 3DS file formats.",
     "homepage": "https://github.com/3DSGuy/Project_CTR/blob/master/ctrtool/README.md",
+    "license": "MIT",
     "architecture": {
         "64bit": {
             "url": "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v1.3.0/ctrtool-v1.3.0-win_x64.zip",

--- a/bucket/ctrtool.json
+++ b/bucket/ctrtool.json
@@ -1,0 +1,30 @@
+{
+    "version": "1.3.0",
+    "description": "A general purpose reading/extraction tool for Nintendo 3DS file formats.",
+    "homepage": "https://github.com/3DSGuy/Project_CTR/blob/master/ctrtool/README.md",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v1.3.0/ctrtool-v1.3.0-win_x64.zip",
+            "hash": "8031dff3be72d0adb250fae1f969f27627e12a89ebc6dd074a15a75f87ddc949"
+        },
+        "32bit": {
+            "url": "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v1.3.0/ctrtool-v1.3.0-win_x86.zip",
+            "hash": "1c1a3c520de8c9924bed4bd2165aa64f5752e36b4a1fcdfa85af062fa17bce75"
+        }
+    },
+    "bin": "ctrtool.exe",
+    "checkver": {
+        "url": "https://github.com/3DSGuy/Project_CTR/releases.atom",
+        "regex": "Repository/\\d+/ctrtool-v([\\d.]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v$version/ctrtool-v$version-win_x64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/3DSGuy/Project_CTR/releases/download/ctrtool-v$version/ctrtool-v$version-win_x86.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added package metadata for ctrtool version 1.3.0.
  * Updated Windows x64 and x86 download information.
  * Improved automatic update and version-checking configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->