### PR TITLE
go-car: Add version 2.17.0

### DIFF
--- a/bucket/go-car.json
+++ b/bucket/go-car.json
@@ -1,0 +1,31 @@
+{
+    "version": "2.17.0",
+    "description": "A Golang implementation of CAR (Content Addressed aRchive) specifications for working with CARv1 and CARv2 files.",
+    "homepage": "https://github.com/ipld/go-car",
+    "license": "Apache-2.0|MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ipld/go-car/releases/download/v2.17.0/go-car_2.17.0_windows_amd64.zip",
+            "hash": "4d47548811da412d49b07e62531ee38bf18751f865ba266682e273fa638a7e91"
+        },
+        "arm64": {
+            "url": "https://github.com/ipld/go-car/releases/download/v2.17.0/go-car_2.17.0_windows_arm64.zip",
+            "hash": "4c162ef355fb5f411cc99ede6630ac492feeef805b95e70e456a37b710dd1ba0"
+        }
+    },
+    "bin": "car.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ipld/go-car/releases/download/v$version/go-car_$version_windows_amd64.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/ipld/go-car/releases/download/v$version/go-car_$version_windows_arm64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/go-car_$version_checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the go-car 2.17.0 Windows package for 64-bit and ARM64 systems.
  * Included architecture-specific downloads, checksums, licensing details, and automatic update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->