### PR TITLE
kcl-kafka: Add version 0.18.0

### DIFF
--- a/bucket/kcl-kafka.json
+++ b/bucket/kcl-kafka.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.18.0",
+    "description": "A complete, pure Go command-line Kafka client for producing, consuming, administering, transactions, and ACLs.",
+    "homepage": "https://github.com/twmb/kcl",
+    "license": "BSD-3-Clause",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/twmb/kcl/releases/download/v0.18.0/kcl_windows_amd64.exe.gz",
+            "hash": "cae77dd97df21fa0ed13f4fd07e4ec57d7295ff2ac8577857a995133283280af"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\" 'kcl?*.exe' | Select-Object -First 1 | Rename-Item -NewName 'kcl.exe'",
+    "bin": "kcl.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/twmb/kcl/releases/download/v$version/kcl_windows_amd64.exe.gz"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added package support for Kafka client tooling version 0.18.0 on Windows.
  - Included download verification, installation setup, executable configuration, and automatic version update metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->