### PR TITLE
papertodo: Add version 3.1

### DIFF
--- a/bucket/papertodo.json
+++ b/bucket/papertodo.json
@@ -1,0 +1,29 @@
+{
+    "version": "3.1",
+    "description": "A minimalist Windows desktop sticky note tool. | 极简 Windows 桌面便签工具",
+    "homepage": "https://github.com/snownico0722/PaperTodo",
+    "license": "Freeware",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/snownico0722/PaperTodo/releases/download/v3.1/PaperTodo-v3.1-win-x64-self-contained.exe#/PaperTodo.exe",
+            "hash": "7e1aed5c2155029c59b34df092bfa074149e5472817d509a7ae8a01da2a2b25f"
+        }
+    },
+    "shortcuts": [
+        [
+            "PaperTodo.exe",
+            "PaperTodo"
+        ]
+    ],
+    "post_install": "Get-ChildItem \"$persist_dir\\backup\\*.json\" | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Move-Item -Force -Destination \"$dir\"",
+    "pre_uninstall": "Get-ChildItem \"$dir\\*.json\" | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Move-Item -Force -Destination \"$persist_dir\\backup\"",
+    "persist": "backup",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/snownico0722/PaperTodo/releases/download/v$version/PaperTodo-v$version-win-x64-self-contained.exe#/PaperTodo.exe"
+            }
+        }
+    }
+}

--- a/bucket/papertodo.json
+++ b/bucket/papertodo.json
@@ -15,8 +15,8 @@
             "PaperTodo"
         ]
     ],
-    "post_install": "Get-ChildItem \"$persist_dir\\backup\\*.json\" | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Move-Item -Force -Destination \"$dir\"",
-    "pre_uninstall": "Get-ChildItem \"$dir\\*.json\" | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Move-Item -Force -Destination \"$persist_dir\\backup\"",
+    "post_install": "Get-ChildItem \"$persist_dir\\backup\\*\" -Include '*.json', '*.lmdb' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Move-Item -Force -Destination \"$dir\"",
+    "pre_uninstall": "Get-ChildItem \"$dir\\*\" -Include '*.json', '*.lmdb' | Where-Object { $_.Name -notin @('manifest.json', 'install.json') } | Move-Item -Force -Destination \"$persist_dir\\backup\"",
     "persist": "backup",
     "checkver": "github",
     "autoupdate": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added installation support for PaperTodo v3.1 on 64-bit Windows.
  * Added desktop shortcut creation and automatic update configuration.
  * Added backup restoration after installation and backup archival before uninstallation.
  * Added download integrity verification and version checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->