### PR TITLE
cqlsh-rs: Add version 0.5.14

### DIFF
--- a/bucket/cqlsh-rs.json
+++ b/bucket/cqlsh-rs.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.5.14",
+    "description": "A ground-up Rust re-implementation of the Python cqlsh — the official interactive CQL shell for Apache Cassandra and compatible databases (ScyllaDB, Amazon Keyspaces, Astra DB).",
+    "homepage": "https://scylladb.github.io/cqlsh-rs/",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/scylladb/cqlsh-rs/releases/download/v0.5.14/cqlsh-rs-0.5.14-x86_64-pc-windows-msvc.zip",
+            "hash": "4ccc9f6828a15ff0015a1f311dc1e408c1d80efbe5f6a629a9479bbe3be3cbf4",
+            "extract_dir": "cqlsh-rs-0.5.14-x86_64-pc-windows-msvc"
+        }
+    },
+    "bin": "cqlsh-rs.exe",
+    "checkver": {
+        "github": "https://github.com/scylladb/cqlsh-rs"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/scylladb/cqlsh-rs/releases/download/v$version/cqlsh-rs-$version-x86_64-pc-windows-msvc.zip",
+                "extract_dir": "cqlsh-rs-$version-x86_64-pc-windows-msvc"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/SHA256SUMS.txt"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for installing `cqlsh-rs` version 0.5.14 on Windows 64-bit systems.
  * Included package metadata, integrity verification, and automatic version update configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->