### PR TITLE
fstar: Add version 2026.08.02

### DIFF
--- a/bucket/fstar.json
+++ b/bucket/fstar.json
@@ -1,0 +1,24 @@
+{
+    "version": "2026.08.02",
+    "description": "A proof-oriented programming language.",
+    "homepage": "https://fstar-lang.org",
+    "license": "Apache-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/FStarLang/FStar/releases/download/v2026.08.02/fstar-v2026.08.02-Windows_NT-x86_64.zip",
+            "hash": "07044e65107907f447e17c07e22d0e37f48372120afd174a7285dedf86197436"
+        }
+    },
+    "extract_dir": "fstar",
+    "bin": "bin\\fstar.exe",
+    "checkver": {
+        "github": "https://github.com/FStarLang/FStar"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/FStarLang/FStar/releases/download/v$version/fstar-v$version-Windows_NT-x86_64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop installation support for F* version 2026.08.02.
  * Included Windows 64-bit download metadata, checksum verification, executable configuration, and automatic version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->