### PR TITLE
aspire: Add version 13.4.6

### DIFF
--- a/bucket/aspire.json
+++ b/bucket/aspire.json
@@ -1,0 +1,30 @@
+{
+    "version": "13.4.6",
+    "description": "A multi-language, code-first toolchain for building, running, and deploying distributed applications.",
+    "homepage": "https://aspire.dev",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/microsoft/aspire/releases/download/v13.4.6/aspire-cli-win-x64-13.4.6.zip",
+            "hash": "38093dc81daf329b487e259bfc608eef3cb663d4cecf6e2b5f29c8513129cd68"
+        },
+        "arm64": {
+            "url": "https://github.com/microsoft/aspire/releases/download/v13.4.6/aspire-cli-win-arm64-13.4.6.zip",
+            "hash": "e48de26619f10a27fc7899f478f95f6266d35f556a7d6bec100669d247ca0130"
+        }
+    },
+    "bin": "aspire.exe",
+    "checkver": {
+        "github": "https://github.com/microsoft/aspire"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/microsoft/aspire/releases/download/v$version/aspire-cli-win-x64-$version.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/microsoft/aspire/releases/download/v$version/aspire-cli-win-arm64-$version.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop installation support for Aspire version 13.4.6.
  * Included Windows x64 and ARM64 downloads with checksum verification.
  * Added automatic version checks and architecture-specific update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->