### PR TITLE
pssdiag: Add version 16.23.08.08

### DIFF
--- a/bucket/pssdiag.json
+++ b/bucket/pssdiag.json
@@ -1,0 +1,19 @@
+{
+    "version": "16.23.08.08",
+    "description": "A graphic interface that provides customization capabilities to collect data for SQL Server using sqldiag collector engine.",
+    "homepage": "https://github.com/microsoft/DiagManager",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/microsoft/DiagManager/releases/download/Win16.23.08.08/PSSDIAG_v_16_23_08_08.zip",
+            "hash": "7f348e880bf16fdd90d65789fc8d9342c1b57aa824ee102db6f55f6775827afb"
+        }
+    },
+    "shortcuts": [
+        [
+            "DiagManager.exe",
+            "Pssdiag/Sqldiag Configuration Manager"
+        ]
+    ],
+    "notes": "The pssidag Configuration Manager utility is no longer in active development and will not receive future updates."
+}

--- a/bucket/pssdiag.json
+++ b/bucket/pssdiag.json
@@ -11,5 +11,5 @@
             "Pssdiag/Sqldiag Configuration Manager"
         ]
     ],
-    "notes": "The pssidag Configuration Manager utility is no longer in active development and will not receive future updates."
+    "notes": "The pssdiag Configuration Manager utility is no longer in active development and will not receive future updates."
 }

--- a/bucket/pssdiag.json
+++ b/bucket/pssdiag.json
@@ -3,12 +3,8 @@
     "description": "A graphic interface that provides customization capabilities to collect data for SQL Server using sqldiag collector engine.",
     "homepage": "https://github.com/microsoft/DiagManager",
     "license": "MIT",
-    "architecture": {
-        "64bit": {
-            "url": "https://github.com/microsoft/DiagManager/releases/download/Win16.23.08.08/PSSDIAG_v_16_23_08_08.zip",
-            "hash": "7f348e880bf16fdd90d65789fc8d9342c1b57aa824ee102db6f55f6775827afb"
-        }
-    },
+    "url": "https://github.com/microsoft/DiagManager/releases/download/Win16.23.08.08/PSSDIAG_v_16_23_08_08.zip",
+    "hash": "7f348e880bf16fdd90d65789fc8d9342c1b57aa824ee102db6f55f6775827afb",
     "shortcuts": [
         [
             "DiagManager.exe",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added PSSDIAG version 16.23.08.08 to the available utilities.
  - Included download verification details and a convenient DiagManager shortcut.
  - Noted that PSSDIAG is no longer actively developed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->