### PR TITLE
shell-use: Add version 0.0.1-beta.6

### DIFF
--- a/bucket/shell-use.json
+++ b/bucket/shell-use.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.0.1-beta.6",
+    "description": "Make the terminal/shell accessible for AI agents to automate tasks with ease.",
+    "homepage": "https://github.com/microsoft/shell-use",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/microsoft/shell-use/releases/download/v0.0.1-beta.6/shell-use-x86_64-pc-windows-msvc.zip",
+            "hash": "c48df4c0bb179c1ca3f6c1b9747d5fb9f286d19b89b48d879d053d30a10f3b95"
+        },
+        "arm64": {
+            "url": "https://github.com/microsoft/shell-use/releases/download/v0.0.1-beta.6/shell-use-aarch64-pc-windows-msvc.zip",
+            "hash": "be341dde121c463fad08ab479aaafd6fa37bcc80e3a3d3bdf7045cbe9e9dbf1a"
+        }
+    },
+    "bin": "shell-use.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/microsoft/shell-use/releases/download/v$version/shell-use-x86_64-pc-windows-msvc.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/microsoft/shell-use/releases/download/v$version/shell-use-aarch64-pc-windows-msvc.zip"
+            }
+        }
+    }
+}

--- a/bucket/shell-use.json
+++ b/bucket/shell-use.json
@@ -14,7 +14,10 @@
         }
     },
     "bin": "shell-use.exe",
-    "checkver": "github",
+    "checkver": {
+        "url": "https://github.com/microsoft/shell-use/releases.atom",
+        "regex": "Repository/\\d+/v(.+?)<"
+    },
     "autoupdate": {
         "architecture": {
             "64bit": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop installation support for shell-use beta.6 on Windows.
  * Supports both 64-bit and ARM64 systems.
  * Enables release checks and version-aware updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->