### PR TITLE
youtui: Add version 0.0.38

### DIFF
--- a/bucket/youtui.json
+++ b/bucket/youtui.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.0.38",
+    "description": "A simple TUI for YouTube Music.",
+    "homepage": "https://github.com/nick42d/youtui",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/youtui-0.0.38/youtui-0.0.38-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "5a591ebda6ddf272efb99694b3188653dd03a652948f121695b6bac99187f555"
+        },
+        "arm64": {
+            "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/youtui-0.0.38/youtui-0.0.38-aarch64-pc-windows-msvc.tar.gz",
+            "hash": "8168e41c08b1b046f07fd24f30b6fe3c400d783e9d7d123c75ed02799a48c4a3"
+        }
+    },
+    "bin": "youtui.exe",
+    "checkver": {
+        "url": "https://crates.io/api/v1/crates/youtui?include=default_version",
+        "jsonpath": "$.crate.default_version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/youtui-$version/youtui-$version-x86_64-pc-windows-msvc.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/youtui-$version/youtui-$version-aarch64-pc-windows-msvc.tar.gz"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for youtui version 0.0.38.
  * Included Windows x64 and ARM64 installation options.
  * Enabled version checking and architecture-specific updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->