### PR TITLE
cc-switch-cli: Add version 5.10.1

### DIFF
--- a/bucket/cc-switch-cli.json
+++ b/bucket/cc-switch-cli.json
@@ -1,0 +1,24 @@
+{
+    "version": "5.10.1",
+    "description": "An all-in-one CLI assistant for Claude Code, Codex, and Gemini CLI.",
+    "homepage": "https://github.com/SaladDay/cc-switch-cli",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/SaladDay/cc-switch-cli/releases/download/v5.10.1/cc-switch-cli-windows-x64.zip",
+            "hash": "143c3a836c3da07a0c63e104d3d6385ed617f6f70a3139b154a2be9752974585"
+        }
+    },
+    "bin": "cc-switch.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/SaladDay/cc-switch-cli/releases/download/v$version/cc-switch-cli-windows-x64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for installing `cc-switch-cli` version 5.10.1 on 64-bit Windows.
  * Enabled version checking and automatic updates through Scoop.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->