### PR TITLE
rsop: Add version 0.11.0

### DIFF
--- a/bucket/rsop.json
+++ b/bucket/rsop.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.11.0",
+    "description": "A stateless OpenPGP (SOP) CLI tool based on rPGP and rpgpie.",
+    "homepage": "https://codeberg.org/heiko/rsop",
+    "license": "CC0-1.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/rsop-0.11.0/rsop-0.11.0-x86_64-pc-windows-msvc.tar.gz",
+            "hash": "e5a22e06e6800539a2f0cfaa81b59c42739cbf39c9155c59258ec23607e074ff"
+        },
+        "arm64": {
+            "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/rsop-0.11.0/rsop-0.11.0-aarch64-pc-windows-msvc.tar.gz",
+            "hash": "4b9c1a7b08dd2cf59180c4c558587c3fc3104be19906bb2d5204f77f97b87c54"
+        }
+    },
+    "bin": "rsop.exe",
+    "checkver": {
+        "url": "https://crates.io/api/v1/crates/rsop?include=default_version",
+        "jsonpath": "$.crate.default_version"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/rsop-$version/rsop-$version-x86_64-pc-windows-msvc.tar.gz"
+            },
+            "arm64": {
+                "url": "https://github.com/cargo-bins/cargo-quickinstall/releases/download/rsop-$version/rsop-$version-aarch64-pc-windows-msvc.tar.gz"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for rsop version 0.11.0.
  * Included Windows 64-bit and ARM64 downloads with integrity verification.
  * Added automatic version checking and architecture-specific update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->