### PR TITLE
lertaro: Add version 4.6.0

### DIFF
--- a/bucket/lertaro.json
+++ b/bucket/lertaro.json
@@ -26,6 +26,7 @@
         "if ($purge) { Remove-Item -Path 'HKCU:\\Software\\Classes\\lertaro' -Recurse -ErrorAction SilentlyContinue }",
         "if ($purge) { Remove-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'Lertaro' -ErrorAction SilentlyContinue }"
     ],
+    "persist": "Data",
     "checkver": {
         "github": "https://github.com/Lertaro/Lertaro"
     },

--- a/bucket/lertaro.json
+++ b/bucket/lertaro.json
@@ -1,0 +1,42 @@
+{
+    "version": "4.6.0",
+    "description": "A modern, high-performance local file search and productivity launcher for Windows. | 超轻量、极速、高度可扩展的 Windows 全局搜索与效率启动工具",
+    "homepage": "https://lertaro.github.io",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/Lertaro/Lertaro/releases/download/v4.6.0/Lertaro-Portable.zip",
+            "hash": "2b896a6766fb8b99a36fc67811ad2d3b9b608bf7ee4c0eae75da40a8be819544"
+        },
+        "arm64": {
+            "url": "https://github.com/Lertaro/Lertaro/releases/download/v4.6.0/Lertaro-Portable-arm64.zip",
+            "hash": "d0765397a78567707170ffa8bec0849eb6fbeb749a7894ed73a5f5af376b04ef"
+        }
+    },
+    "extract_dir": "Lertaro",
+    "bin": "lff.exe",
+    "shortcuts": [
+        [
+            "Lertaro.App.exe",
+            "Lertaro"
+        ]
+    ],
+    "pre_uninstall": "if (Get-Service -Name 'LertaroService' -ErrorAction SilentlyContinue | Where-Object { $_.Status -eq 'Running' }) { warn \"If file locks prevent uninstallation, run 'sudo sc stop LertaroService' and 'sudo sc delete LertaroService' manually.\" }",
+    "post_uninstall": [
+        "if ($purge) { Remove-Item -Path 'HKCU:\\Software\\Classes\\lertaro' -Recurse -ErrorAction SilentlyContinue }",
+        "if ($purge) { Remove-ItemProperty -Path 'HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run' -Name 'Lertaro' -ErrorAction SilentlyContinue }"
+    ],
+    "checkver": {
+        "github": "https://github.com/Lertaro/Lertaro"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/Lertaro/Lertaro/releases/download/v$version/Lertaro-Portable.zip"
+            },
+            "arm64": {
+                "url": "https://github.com/Lertaro/Lertaro/releases/download/v$version/Lertaro-Portable-arm64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Scoop installation support for Lertaro 4.6.0.
  - Supports Windows 64-bit and ARM64 architectures.
  - Includes an application shortcut and automatic version updates.
  - Adds cleanup handling when uninstalling, including service-aware removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->