### PR TITLE
undertalemodtool: Add version 0.9.1.2

### DIFF
--- a/bucket/undertalemodtool-cli.json
+++ b/bucket/undertalemodtool-cli.json
@@ -1,0 +1,21 @@
+{
+    "version": "0.9.1.2",
+    "description": "CLI version of UndertaleModTool, a tool for modding, decompiling and unpacking Undertale and other GameMaker games.",
+    "homepage": "https://github.com/UnderminersTeam/UndertaleModTool",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/UnderminersTeam/UndertaleModTool/releases/download/0.9.1.2/UTMT_CLI_v0.9.1.2-Windows.zip",
+            "hash": "e17637750c9c5bd074e799de99e69e1aa58c19cbbd9cbaa8868bbc387da04345"
+        }
+    },
+    "bin": "UndertaleModCli.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/UnderminersTeam/UndertaleModTool/releases/download/$version/UTMT_CLI_v$version-Windows.zip"
+            }
+        }
+    }
+}

--- a/bucket/undertalemodtool.json
+++ b/bucket/undertalemodtool.json
@@ -1,0 +1,26 @@
+{
+    "version": "0.9.1.2",
+    "description": "A complete tool for modding, decompiling and unpacking Undertale and other GameMaker games.",
+    "homepage": "https://github.com/UnderminersTeam/UndertaleModTool",
+    "license": "GPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/UnderminersTeam/UndertaleModTool/releases/download/0.9.1.2/UndertaleModTool_v0.9.1.2-Windows.zip",
+            "hash": "0f9ad0b81c8b3074537100544a6a9e5bb7092fa923459e6ba3bb22b8c7cc08b3"
+        }
+    },
+    "shortcuts": [
+        [
+            "UndertaleModTool.exe",
+            "UndertaleModTool"
+        ]
+    ],
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/UnderminersTeam/UndertaleModTool/releases/download/$version/UndertaleModTool_v$version-Windows.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Scoop installation manifests for UndertaleModTool and UndertaleModTool CLI version 0.9.1.2.
  - Included Windows 64-bit downloads, integrity verification, executable shortcuts, and automatic version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->