### PR TITLE
dedao-dl: Add version 1.2.27

### DIFF
--- a/bucket/dedao-dl.json
+++ b/bucket/dedao-dl.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.2.27",
+    "description": "得到 APP 课程下载工具，可在终端查看文章内容，可生成 PDF，音频文件，markdown 文稿",
+    "homepage": "https://github.com/yann0917/dedao-dl",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/yann0917/dedao-dl/releases/download/v1.2.27/dedao-dl-windows-amd64.zip",
+            "hash": "62db5d051f03dd5fb155a00fdbcb2ed5329618e087478b4e52836793c40dda62"
+        }
+    },
+    "pre_install": "Get-ChildItem \"$dir\" 'dedao-dl?*.exe' | Select-Object -First 1 | Rename-Item -NewName 'dedao-dl.exe'",
+    "bin": "dedao-dl.exe",
+    "suggest": {
+        "wkhtmltopdf": "wkhtmltopdf",
+        "ffmpeg": "ffmpeg"
+    },
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/yann0917/dedao-dl/releases/download/v$version/dedao-dl-windows-amd64.zip"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop installation support for dedao-dl version 1.2.27.
  * Included Windows 64-bit download and checksum verification.
  * Added executable setup, optional dependencies, version checking, and automatic update configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->