### PR TITLE
fooyin: Add version 0.12.6

### DIFF
--- a/bucket/fooyin.json
+++ b/bucket/fooyin.json
@@ -1,0 +1,42 @@
+{
+    "version": "0.12.6",
+    "description": "A customisable music player.",
+    "homepage": "https://fooyin.org/",
+    "license": "GPL-3.0-or-later",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/fooyin/fooyin/releases/download/v0.12.6/fooyin-0.12.6-windows-x64-portable.zip",
+            "hash": "e458024146b23655db30a4372e1c815def03b8a7d4662327b7b8ac44a9ff9f64"
+        },
+        "arm64": {
+            "url": "https://github.com/fooyin/fooyin/releases/download/v0.12.6/fooyin-0.12.6-windows-arm64-portable.zip",
+            "hash": "3359e68a114fa2ed41b0b296aca017b74872f61f11042dbdb53e172592a4d65f"
+        }
+    },
+    "shortcuts": [
+        [
+            "fooyin.exe",
+            "fooyin"
+        ]
+    ],
+    "persist": [
+        "data",
+        "config",
+        "cache"
+    ],
+    "checkver": {
+        "github": "https://github.com/fooyin/fooyin"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/fooyin/fooyin/releases/download/v$version/fooyin-$version-windows-x64-portable.zip",
+                "extract_dir": "fooyin-$version-windows-x64-portable"
+            },
+            "arm64": {
+                "url": "https://github.com/fooyin/fooyin/releases/download/v$version/fooyin-$version-windows-arm64-portable.zip",
+                "extract_dir": "fooyin-$version-windows-arm64-portable"
+            }
+        }
+    }
+}

--- a/bucket/fooyin.json
+++ b/bucket/fooyin.json
@@ -6,10 +6,12 @@
     "architecture": {
         "64bit": {
             "url": "https://github.com/fooyin/fooyin/releases/download/v0.12.6/fooyin-0.12.6-windows-x64-portable.zip",
+            "extract_dir": "fooyin-0.12.6-windows-x64-portable",
             "hash": "e458024146b23655db30a4372e1c815def03b8a7d4662327b7b8ac44a9ff9f64"
         },
         "arm64": {
             "url": "https://github.com/fooyin/fooyin/releases/download/v0.12.6/fooyin-0.12.6-windows-arm64-portable.zip",
+            "extract_dir": "fooyin-0.12.6-windows-arm64-portable",
             "hash": "3359e68a114fa2ed41b0b296aca017b74872f61f11042dbdb53e172592a4d65f"
         }
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop installation support for Fooyin 0.12.6 on 64-bit and ARM64 Windows.
  * Added a Start Menu shortcut for launching Fooyin.
  * Preserved user data, configuration, and cache files across updates.
  * Enabled automatic version checking and architecture-specific update downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->