### PR TITLE
signtools: Add version 3.0.12

### DIFF
--- a/bucket/signtools.json
+++ b/bucket/signtools.json
@@ -1,0 +1,33 @@
+{
+    "version": "3.0.12",
+    "description": "A free, self-hosted platform to sign and install iOS apps without a computer.",
+    "homepage": "https://github.com/SignTools/SignTools",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/SignTools/SignTools/releases/download/v3.0.12/SignTools_3.0.12_windows_amd64.exe#/SignTools.exe",
+            "hash": "608d5a92127ab0f62bb660559044f27280c259748aeb0f9a1f27d776598943c2"
+        },
+        "arm64": {
+            "url": "https://github.com/SignTools/SignTools/releases/download/v3.0.12/SignTools_3.0.12_windows_arm64.exe#/SignTools.exe",
+            "hash": "2307e8ed9a2575e04d688c37ad5bfa64f9629dd1f2beca42ed2ee154404c6240"
+        }
+    },
+    "bin": "SignTools.exe",
+    "checkver": {
+        "github": "https://github.com/SignTools/SignTools"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/SignTools/SignTools/releases/download/v$version/SignTools_$version_windows_amd64.exe#/SignTools.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/SignTools/SignTools/releases/download/v$version/SignTools_$version_windows_arm64.exe#/SignTools.exe"
+            }
+        },
+        "hash": {
+            "url": "$baseurl/checksums.txt"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for SignTools version 3.0.12.
  * Included installation options for Windows 64-bit and ARM64 systems.
  * Enabled automatic version checks and updates with checksum verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->