### PR TITLE
brogue-ce: Add version 1.15.1

### DIFF
--- a/bucket/brogue-ce.json
+++ b/bucket/brogue-ce.json
@@ -1,0 +1,33 @@
+{
+    "version": "1.15.1",
+    "description": "Brogue: Community Edition, a community-lead fork of the minimalist roguelike game.",
+    "homepage": "https://github.com/tmewett/BrogueCE",
+    "license": "AGPL-3.0-only",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/tmewett/BrogueCE/releases/download/v1.15.1/BrogueCE-1.15.1-windows-x86_64.zip",
+            "hash": "29dcbae1791156a040c9125d0a28ae97d67a09b22a52266af1c65e2918bede5f"
+        }
+    },
+    "extract_dir": "BrogueCE-windows",
+    "bin": "brogue.exe",
+    "shortcuts": [
+        [
+            "brogue.exe",
+            "Brogue CE"
+        ]
+    ],
+    "post_install": "Get-ChildItem \"$persist_dir\\backup\\*\" -Include '*.broguesave', '*.broguerec', '*.png', '*.txt' | Move-Item -Force -Destination \"$dir\"",
+    "pre_uninstall": "Get-ChildItem \"$dir\\*\" -Include '*.broguesave', '*.broguerec', '*.png', '*.txt' | Move-Item -Force -Destination \"$persist_dir\\backup\"",
+    "persist": "backup",
+    "checkver": {
+        "github": "https://github.com/tmewett/BrogueCE"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/tmewett/BrogueCE/releases/download/v$version/BrogueCE-$version-windows-x86_64.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Brogue: Community Edition v1.15.1 as an installable package.
  * Configured 64-bit download and integrity verification.
  * Added executable and shortcut registration for convenient launching.
  * Added automatic save-file preservation during installation and removal.
  * Enabled version checking and update support from GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->