### PR TITLE
fff-mcp: Add version 0.10.6

### DIFF
--- a/bucket/fff-mcp.json
+++ b/bucket/fff-mcp.json
@@ -1,0 +1,31 @@
+{
+    "version": "0.10.6",
+    "description": "An MCP server exposing the fff file search engine to AI agents.",
+    "homepage": "https://github.com/dmtrKovalenko/fff",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/dmtrKovalenko/fff/releases/download/v0.10.6/fff-mcp-x86_64-pc-windows-msvc.exe#/fff-mcp.exe",
+            "hash": "460e0614f4e8d6b6b618ec9b4bc5eeb58d70601d8b62c7947cc66435a182f946"
+        },
+        "arm64": {
+            "url": "https://github.com/dmtrKovalenko/fff/releases/download/v0.10.6/fff-mcp-aarch64-pc-windows-msvc.exe#/fff-mcp.exe",
+            "hash": "9151f6efc9d5aa9e38aafb7fb2c664700fa950374717305ad41a09a54cfe873e"
+        }
+    },
+    "bin": "fff-mcp.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/dmtrKovalenko/fff/releases/download/v$version/fff-mcp-x86_64-pc-windows-msvc.exe#/fff-mcp.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/dmtrKovalenko/fff/releases/download/v$version/fff-mcp-aarch64-pc-windows-msvc.exe#/fff-mcp.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Scoop package support for installing the `fff-mcp` server on Windows, including 64-bit and ARM64 architectures.
  * Added version checking and automatic update metadata for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->