### PR TITLE
brave-search-cli: Add version 1.7.0

### DIFF
--- a/bucket/brave-search-cli.json
+++ b/bucket/brave-search-cli.json
@@ -1,0 +1,31 @@
+{
+    "version": "1.7.0",
+    "description": "A zero-dependency, token-efficient CLI for the Brave Search API, built for AI agents and LLMs.",
+    "homepage": "https://github.com/brave/brave-search-cli",
+    "license": "MPL-2.0",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/brave/brave-search-cli/releases/download/v1.7.0/bx-1.7.0-windows-amd64.exe#/bx.exe",
+            "hash": "672170b4551ed328bdb79416a706e0a4acea3e671b1bb412a1cd67def71af703"
+        },
+        "arm64": {
+            "url": "https://github.com/brave/brave-search-cli/releases/download/v1.7.0/bx-1.7.0-windows-arm64.exe#/bx.exe",
+            "hash": "0683e0d11380d409a148453b072d4a844edc39557c68218cc08beb5c75959f30"
+        }
+    },
+    "bin": "bx.exe",
+    "checkver": "github",
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/brave/brave-search-cli/releases/download/v$version/bx-$version-windows-amd64.exe#/bx.exe"
+            },
+            "arm64": {
+                "url": "https://github.com/brave/brave-search-cli/releases/download/v$version/bx-$version-windows-arm64.exe#/bx.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for installing and updating the Brave Search CLI (`bx`) version 1.7.0 on Windows 64-bit and ARM64 systems.
  - Included architecture-specific downloads, integrity verification, version checks, and automatic update support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->